### PR TITLE
M2 integration: docs, slides, cross-platform paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-## How to run Milestone 2
+## Milestone 2
+
+See `docs/milestone2_readme.md` for the final Milestone 2 submission writeup, outputs, and traceability.
 
 ## Run pipeline
 python scripts/download_raw.py

--- a/docs/milestone2_readme.md
+++ b/docs/milestone2_readme.md
@@ -1,0 +1,71 @@
+# Milestone 2 — Data Preparation & Federated Partitioning (Submission)
+
+## Goal
+Prepare a clean, reproducible Milestone 2 dataset and diagnostics so the repository is ready for Milestone 3 (federated model training) without rework.
+
+## What’s included
+- Dataset acquisition and basic validation
+- Preprocessing + pseudo-label creation
+- Federated partitioning into 3 clients (replicates)
+- Client heterogeneity / non-IID diagnostics (plots + tables)
+
+## Repository layout (relevant paths)
+- `data/raw/`
+  - `10xgenomics_xenium_mouse_brain_replicates.h5ad` (downloaded)
+  - `basic_stats.json` (validation summary)
+- `data/processed/`
+  - `processed_table.parquet` (global processed table)
+  - `genes.txt` (gene schema / order)
+  - `label_map.json` (pseudo-label encoding)
+  - `global_metadata.json` (client summary)
+  - `clients/client_XX/{train,val,test}.parquet` and `client_meta.json`
+- Documentation
+  - `md/data_dictionary.md` (data contract)
+  - `md/preprocessing_notes.md` (pseudo-labeling + preprocessing decisions)
+  - `md/partitioning_strategy.md` (client split definition)
+  - `md/client_stats_summary.md` (non-IID diagnostics writeup)
+- Presentation-ready figures/tables
+  - `md/figures/*.png`
+  - `md/figures/*.csv`
+
+## Important decision: labels
+The raw dataset contains annotation columns (e.g. `niche`, `region`), but in this benchmark file the available label columns are not usable for supervised learning (only a single unique value). For Milestone 2 we therefore generate **pseudo-labels** via Leiden clustering.
+
+- Label column used downstream: `label` (integer)
+- Origin: `adata.obs["cluster"]` from Leiden
+- Mapping stored in: `data/processed/label_map.json`
+
+Details: `md/preprocessing_notes.md`
+
+## How to run (Milestone 2 pipeline)
+Run in this order:
+
+```bash
+python scripts/download_raw.py
+python scripts/validate_raw.py
+python scripts/preprocess.py
+python scripts/partition_clients.py
+python scripts/client_stats.py
+```
+
+### Expected outputs after running
+- `data/raw/basic_stats.json`
+- `data/processed/processed_table.parquet`
+- `data/processed/genes.txt`
+- `data/processed/label_map.json`
+- `data/processed/clients/client_01/` … `client_03/`
+- Figures/tables under `md/figures/`
+
+## Diagnostics outputs (used in slides)
+- `md/figures/spatial_clusters.png`
+- `md/figures/client_sizes.png`
+- `md/figures/global_label_distribution.png`
+- `md/figures/per_client_label_distribution.png`
+- `md/figures/client_imbalance_max_fraction.png`
+- `md/figures/client_jsd_to_global.png`
+
+## Traceability
+- Data contract: `md/data_dictionary.md`
+- Preprocessing rationale: `md/preprocessing_notes.md`
+- Partitioning rationale: `md/partitioning_strategy.md`
+- Non-IID metrics + tables: `md/client_stats_summary.md` and `md/figures/*.csv`

--- a/md/data_dictionary.md
+++ b/md/data_dictionary.md
@@ -20,7 +20,7 @@ To maintain consistency across the pipeline, use the following mapping from the 
 | Contract Field | Raw Column Name | Type | Description |
 | :--- | :--- | :--- | :--- |
 | **sample_id** | `library_key` | category | **Primary Split Axis.** Each unique key is a federated client. |
-| **label** | `niche` | category | Target labels for fine-tuning (e.g., "Cortex_L2", "Hippocampus"). |
+| **label** | derived (`cluster`) | category | Pseudo-labels created via Leiden clustering during preprocessing. |
 | **x** | `x` | float32 | Spatial X-coordinate (centroid). |
 | **y** | `y` | float32 | Spatial Y-coordinate (centroid). |
 | **donor_id** | `donor_id` | category | Biological source identifier. |
@@ -48,12 +48,11 @@ Based on the validation of the raw Xenium data, please follow these requirements
 - Verify if `adata.X` contains integers (raw) or floats (normalized) before applying.
 
 ### C. Label Standardization (`label_map.json`)
-- The `niche` column contains the ground-truth labels.
-- **Task:** Create a consistent `label_map.json` that maps these string labels to integers (0, 1, 2...). 
+- Labels are generated during preprocessing as Leiden cluster IDs (stored in `adata.obs["cluster"]`).
+- **Task:** Create a consistent `label_map.json` that maps these cluster IDs (strings) to integers (0, 1, 2...). 
 - **Important:** This map must be applied globally to all clients so that "Client A's" Label 0 is the same as "Client B's" Label 0.
 
 ### D. File Outputs
 - **`processed_table.parquet`**: Should contain `id`, `sample_id` (from `library_key`), `x`, `y`, `label` (int), and the 248 gene columns.
 - **`genes.txt`**: A line-separated file of the 248 genes in the exact order used in the parquet columns.
-- **`label_map.json`**: The dictionary used for encoding the `niche` labels.
-
+- **`label_map.json`**: The dictionary used for encoding the Leiden cluster pseudo-labels.

--- a/scripts/client_stats.py
+++ b/scripts/client_stats.py
@@ -5,9 +5,9 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 
-CLIENTS_DIR = r"data\processed\clients"
-OUT_DIR = r"md\figures"
-SUMMARY_MD = r"md\client_stats_summary.md"
+CLIENTS_DIR = os.path.join("data", "processed", "clients")
+OUT_DIR = os.path.join("md", "figures")
+SUMMARY_MD = os.path.join("md", "client_stats_summary.md")
 
 os.makedirs(OUT_DIR, exist_ok=True)
 

--- a/scripts/partition_clients.py
+++ b/scripts/partition_clients.py
@@ -2,8 +2,8 @@ import os, json
 import numpy as np
 import pandas as pd
 
-IN_PATH = r"data\processed\processed_table.parquet"
-OUT_DIR = r"data\processed\clients"
+IN_PATH = os.path.join("data", "processed", "processed_table.parquet")
+OUT_DIR = os.path.join("data", "processed", "clients")
 LABEL_COL = "label"
 CLIENT_COL = "sample_id"
 SPLIT = (0.8, 0.1, 0.1)
@@ -53,7 +53,7 @@ for i, (client_id, cdf) in enumerate(df.groupby(CLIENT_COL), start=1):
 
     global_meta[client_name] = meta
 
-with open(r"data\processed\global_metadata.json", "w") as f:
+with open(os.path.join("data", "processed", "global_metadata.json"), "w") as f:
     json.dump(global_meta, f, indent=2)
 
 print(f"Saved {len(global_meta)} clients to {OUT_DIR}")

--- a/slides/milestone2.md
+++ b/slides/milestone2.md
@@ -1,0 +1,73 @@
+# Milestone 2 — Data Preparation & Federated Partitioning
+
+## Milestone 2 objectives
+- Build a clean, reproducible dataset pipeline
+- Create federated clients from replicates
+- Quantify client heterogeneity (non-IID)
+- Produce figures/tables ready for Milestone 3 and presentation
+
+## Dataset
+- Xenium Mouse Brain Replicates (10x Genomics)
+- ~475k cells, 248 targeted genes
+- Split axis (clients): `library_key` → `sample_id`
+
+## Pipeline overview
+- Download raw data
+- Validate raw schema + basic stats
+- Preprocess (normalize + log1p)
+- Create pseudo-labels (Leiden)
+- Create 3 federated clients with stratified train/val/test
+- Compute client diagnostics + non-IID metrics
+
+## Label strategy (pseudo-labels)
+- Raw annotation columns are not usable as supervised labels in this benchmark file
+- We generate pseudo-labels via:
+  - PCA (30 comps)
+  - Neighbors (15, 30 PCs)
+  - Leiden (resolution 0.5)
+- Mapping stored in `data/processed/label_map.json`
+
+## Federated partitioning
+- 3 clients from replicates
+- Output per client:
+  - `train.parquet`, `val.parquet`, `test.parquet`
+  - `client_meta.json`
+- Global summary: `data/processed/global_metadata.json`
+
+## Client sizes
+![](../md/figures/client_sizes.png)
+
+## Global label distribution
+![](../md/figures/global_label_distribution.png)
+
+## Per-client label distribution
+![](../md/figures/per_client_label_distribution.png)
+
+## Within-client imbalance
+![](../md/figures/client_imbalance_max_fraction.png)
+
+## Non-IID severity (JSD to global)
+![](../md/figures/client_jsd_to_global.png)
+
+## Spatial clusters (pseudo-labels)
+![](../md/figures/spatial_clusters.png)
+
+## Key takeaways
+- Clients are balanced in size
+- Mild within-client imbalance
+- Weak but measurable non-IID across replicates
+- Clean baseline for Milestone 3 experiments
+
+## Reproducibility
+```bash
+python scripts/download_raw.py
+python scripts/validate_raw.py
+python scripts/preprocess.py
+python scripts/partition_clients.py
+python scripts/client_stats.py
+```
+
+## Deliverables
+- `docs/milestone2_readme.md`
+- Figures and tables under `md/figures/`
+- Slide source: `slides/milestone2.md`


### PR DESCRIPTION
fixes #5 - Resolved conceptually: the new code paths are cross-platform and should work for Windows + macOS. Created: docs/milestone2_readme.md (this is your Milestone 2 submission doc).
Updated: README.md to point to docs/milestone2_readme.md and keep the run commands.
Resolved label inconsistency by updating md/data_dictionary.md to reflect the actual pipeline behavior: labels are pseudo-labels from Leiden (not niche).